### PR TITLE
Proxy for Reddit galleries.

### DIFF
--- a/proxy/__init__.py
+++ b/proxy/__init__.py
@@ -9,6 +9,7 @@ from .sources.gist import Gist
 from .sources.mangakatana import MangaKatana
 from .sources.nepnep import NepNep
 from .sources.imgbox import Imgbox
+from .sources.reddit import Reddit
 
 sources = [
     MangaDex(),
@@ -22,4 +23,5 @@ sources = [
     MangaKatana(),
     NepNep(),
     Imgbox(),
+    Reddit(),
 ]

--- a/proxy/sources/reddit.py
+++ b/proxy/sources/reddit.py
@@ -43,7 +43,7 @@ class Reddit(ProxySource):
         api_data = resp.json()
         api_data = api_data["data"]["children"][0]["data"]
 
-        if ("is_galleyr" in api_data and not api_data["is_gallery"]) or api_data["removed_by_category"] != None:
+        if "is_gallery" not in api_data or not api_data["is_gallery"] or api_data["removed_by_category"] != None:
             return None
 
         try:

--- a/static_global/js/main.js
+++ b/static_global/js/main.js
@@ -36,6 +36,12 @@ let error = '';
 			}
 			result = '/read/mangasee/' + slug_name
 			break 
+		case /reddit\.com/i.test(text):
+			result = /reddit.com\/(?:r|u)\/(?:[a-z0-9_]+)\/comments\/([a-z0-9]+)/i.exec(text);
+			if (!result || !result[1]) result = /reddit.com\/gallery\/([a-z0-9]+)/i.exec(text);
+			if (!result || !result[1]) return message('Reader could not understand the given link.', 1);
+			result = '/read/reddit/' + result[1];
+			break;
 		default:
 			return message('Reader could not understand the given link.', 1)
 			break;


### PR DESCRIPTION
This uses the Reddit API.  The docs say OAuth2 is required, but in reality, it doesn't seem to be for read-only stuff.  I don't know if actual usage on Cubari will be any different, but testing on my local instance works (and people say they've been using the Reddit API without authentication).

I could instead scrape the HTML for the gallery, but that seems to expose a little less info about the post but also contains comment data.

It accepts two kinds of URLs:
https://www.reddit.com/gallery/q0o2in
https://www.reddit.com/r/manga/comments/q1wf0n/yugamis_request_yugamikun_ni_wa_tomodachi_ga_inai/

Let me know if you'd like any changes or if I should be doing something more to test than throwing a few Reddit URLs at it.