### PR TITLE
Fix Regex bugs misinterpreting URLs as markdown text. 

### DIFF
--- a/proxy/source/markdown_parser.py
+++ b/proxy/source/markdown_parser.py
@@ -156,10 +156,10 @@ def parse_html(input_str: str) -> str:
     parsers = [
         _convert_crlf,
         _escape,
-        _parse_headers,
         _parse_links,
-        _parse_em_emphasis,
+        _parse_headers,
         _parse_strong_emphasis,
+        _parse_em_emphasis,
         _parse_code,
     ]
 

--- a/proxy/source/markdown_parser.py
+++ b/proxy/source/markdown_parser.py
@@ -54,8 +54,6 @@ def _convert_crlf(input_str: str) -> str:
 
 
 def _parse_links(input_str: str) -> str:
-    input_str = _parse_em_emphasis(input_str)
-
     input_str = re.sub(
         r"\[(.+?)\]\((https?:\/\/[-a-zA-Z0-9._~:/?#@!$&()*+,;=%']+)\)",
         r'<a href="\2" target="_blank" rel="nofollow noreferrer noopener">\1</a>',
@@ -68,7 +66,6 @@ def _parse_links(input_str: str) -> str:
         input_str,
         flags=re.MULTILINE|re.IGNORECASE,
     )
-
 
 def _parse_headers(input_str: str) -> str:
     search = re.finditer(r"^(#{1,5}) +(.+)[# ]?$", input_str, re.MULTILINE)

--- a/proxy/source/markdown_parser.py
+++ b/proxy/source/markdown_parser.py
@@ -166,6 +166,5 @@ def parse_html(input_str: str) -> str:
     intermediate_parse_result = input_str
 
     for parser in parsers:
-        previous_parse_result = intermediate_parse_result
         intermediate_parse_result = parser(intermediate_parse_result)
     return intermediate_parse_result

--- a/proxy/source/markdown_parser.py
+++ b/proxy/source/markdown_parser.py
@@ -54,6 +54,8 @@ def _convert_crlf(input_str: str) -> str:
 
 
 def _parse_links(input_str: str) -> str:
+    input_str = _parse_em_emphasis(input_str)
+
     input_str = re.sub(
         r"\[(.+?)\]\((https?:\/\/[-a-zA-Z0-9._~:/?#@!$&()*+,;=%']+)\)",
         r'<a href="\2" target="_blank" rel="nofollow noreferrer noopener">\1</a>',
@@ -79,28 +81,52 @@ def _parse_headers(input_str: str) -> str:
         )
     return input_str
 
+#Checks whether a string contains a plain non-quoted URL, mainly to later avoid <a herf> fields.
+#Example:
+#    Returns 'true' for: http://example.nonexistant 
+#    Returns 'false' for: "http://example.nonexistnat"
+def _is_plain_url(input_str: str) -> bool:
+    return re.search(r"(?<!\")(https?:\/\/[-a-zA-Z0-9._~:/?#@!$&()*+,;=%']+)(?!\")", input_str) != None
 
 def _parse_strong_emphasis(input_str: str) -> str:
-    return "\n".join(
-        re.sub(
-            r"(?<!\\)\*\*(\w.*?)(?<!\\)\*\*|(?<!\\)__(\w.*?)(?<!\\)__",
-            r"<strong>\1</strong>",
-            l,
-        )
-        for l in input_str.splitlines()
-    )
+    output_str="\n"
 
+    #Iterates over every line and checks for URLs. Applies substition by regex only if there aren't any.
+    #This is necessiary as some URLs can be misinterpreted as markdown text, which promptly messes up the outputed HTML (as was seen here: https://tomo.fukai20.com). 
+
+    #If anyone knows how to do the following purely with a regex, go ahead. I couldn't figure it out
+    # -Night
+
+    for l in input_str.splitlines():
+        if (not _is_plain_url(l)):
+            output_str+=re.sub(
+                    r"(?<!\\)\*\*(\w.*?)(?<!\\)\*\*(?![\\,\"])|(?<!\\)\_\_(\w.*?)(?<!\\)\_\_",
+                    r"<strong>\1\2</strong>",
+                    l,
+                )+"\n"
+        else:
+            output_str+=l + "\n"    
+    return output_str
 
 def _parse_em_emphasis(input_str: str) -> str:
-    return "\n".join(
-        re.sub(
-            r"(?<!\\)\*(\w.*?)(?<!\\)\*|(?<!\\)_(\w.*?)(?<!\\)_",
-            r"<em>\1</em>",
-            l,
-        )
-        for l in input_str.splitlines()
-    )
+    output_str = ""
 
+    #Iterates over every line and checks for URLs. Applies substition by regex only if there aren't any.
+    #This is necessiary as some URLs can be misinterpreted as markdown text, which promptly messes up the outputed HTML (as was seen here: https://tomo.fukai20.com). 
+
+    #If anyone knows how to do the following purely with a regex, go ahead. I couldn't figure it out. 
+    # -Night
+
+    for l in input_str.splitlines():
+        if (not _is_plain_url(l)):
+            output_str+=re.sub(
+                    r"(?<![\\,\"])(?<!\*)\*(\w.*?)(?<!\\)\*(?![\\,\",*])|(?<![\\,\"])(?<!\_)_(?!_)(\w.*?)(?<![\\,\"])_(?!\_)",
+                    r"<em>\1\2</em>",
+                    l,
+                )+"\n"
+        else:
+           output_str+=l + "\n"
+    return output_str
 
 def _parse_code(input_str: str) -> str:
     return "\n".join(
@@ -130,16 +156,16 @@ def parse_html(input_str: str) -> str:
     parsers = [
         _convert_crlf,
         _escape,
-        _parse_links,
         _parse_headers,
-        _parse_strong_emphasis,
+        _parse_links,
         _parse_em_emphasis,
+        _parse_strong_emphasis,
         _parse_code,
     ]
 
     intermediate_parse_result = input_str
 
     for parser in parsers:
+        previous_parse_result = intermediate_parse_result
         intermediate_parse_result = parser(intermediate_parse_result)
-
     return intermediate_parse_result


### PR DESCRIPTION
Bugs found in `proxy/source/markdown_parser.py`:

- Regex were applied to URLs by treating them as text, thus breaking them and sub sequentially creating broken hyperlinks.
- Improper use of some markdown notation also lead to the breaking of the output HTML, in which emphasis tags appeared where they shouldn't be, something that [resulted in this](https://i.imgur.com/7vP6EqJ.png).
- `<strong>` emphasis (bold text) could sometimes be mistaken for `<em>` emphasis (italic text). 

The following fixes were applied:
- Regex for handling both `<em>` and `<bold>` emphasis were modified to include more edge cases.
- Both the `_parse_strong_emphasis` and  `_parse_em_emphasis` functions now explicitly check for plain URLs and skip those that are part of a `<a herf>` field.
  - Open question: do URL strings that also serve as hyperlink text need to be parsed as markdown when used as text? currently they're left as-is.
  - Apologies in advance should the usage of `if/else` statements trigger the person who originally wrote the entire thing purely with regex, feel free to change this back if you can figure out how to properly `AND` two expressions (i couldn't).

For future convince, [here's a Cubari gist for markdown testing that factors for this bug](https://gist.githubusercontent.com/NightA/9e9573514dc4c38921d6f10b1eb390db/raw/markdown.JSON). 