### PR TITLE
fix Reddit regex to allow uppercase in subreddit names

### DIFF
--- a/proxy/sources/reddit.py
+++ b/proxy/sources/reddit.py
@@ -25,7 +25,7 @@ class Reddit(ProxySource):
             )
 
         return [
-            re_path(r"^(?:reddit|r/[a-z0-9_]+/comments)/(?P<meta_id>[\d\w]+)", handler),
+            re_path(r"^(?:reddit|r/[a-zA-Z0-9_]+/comments)/(?P<meta_id>[\d\w]+)", handler),
             re_path(r"^(?:gallery)/(?P<meta_id>[\d\w]+)", handler),
         ]
 

--- a/static_global/js/main.js
+++ b/static_global/js/main.js
@@ -48,7 +48,7 @@ let error = '';
 			result = '/read/weebcentral/' + slug_name
 			break 
 		case /reddit\.com/i.test(text):
-			result = /reddit\.com\/(?:r|u(?:ser)?)\/(?:[a-z0-9_\-]+)\/comments\/([a-z0-9]+)/i.exec(text);
+			result = /reddit\.com\/(?:r|u(?:ser)?)\/(?:[a-zA-Z0-9_\-]+)\/comments\/([a-z0-9]+)/i.exec(text);
 			if (!result || !result[1]) result = /reddit\.com\/gallery\/([a-z0-9]+)/i.exec(text);
 			if (!result || !result[1]) return message('Reader could not understand the given link.', 1);
 			result = '/read/reddit/' + result[1];


### PR DESCRIPTION
For example, https://cubari.moe/r/MadokaMagica/comments/1bbt5bq/ currently 404's even though https://cubari.moe/r/madokamagica/comments/1bbt5bq/ works. I assume the regex was intended to make it possible to just replace "reddit.com" with "cubari.moe" in the URL to get a valid cubari proxy link, so this PR fixes that.