### PR TITLE
Improve Dynasty-Scans support

### DIFF
--- a/proxy/sources/dynasty.py
+++ b/proxy/sources/dynasty.py
@@ -103,7 +103,7 @@ class Dynasty(ProxySource):
                 description = soup.get_text("\n").strip()
             else:
                 description = "No description."
-
+            
             author = next(
                 (tag["name"] for tag in data["tags"] if tag["type"] == "Author"), "Unknown"
             )
@@ -130,9 +130,9 @@ class Dynasty(ProxySource):
             chapter_dict = {}
             volume = None
             
-            for tagging in data["taggings"]:            
+            for tagging in data["taggings"]:
                 if "header" in tagging:
-                    match =  re.match(r"Volume (\d+)", tagging["header"])
+                    match = re.match(r"Volume (\d+)", tagging["header"])
                     if match is None:
                         volume = None
                     else:
@@ -144,9 +144,7 @@ class Dynasty(ProxySource):
                         canonical_chapter = tagging["permalink"].replace(meta_id + "_", "")
                     chapter_title = tagging["title"]
                     upload_date = self.parse_date(tagging["released_on"])
-                    groups = [
-                        tag["name"] for tag in tagging["tags"] if tag["type"] == "Scanlator"
-                    ]
+                    groups = [tag["name"] for tag in tagging["tags"] if tag["type"] == "Scanlator"]
                     group = ", ".join(groups)
                     
                     chapter_list.append(

--- a/proxy/sources/dynasty.py
+++ b/proxy/sources/dynasty.py
@@ -1,10 +1,7 @@
-import json
 import re
-import ast
 from datetime import datetime
 
 from bs4 import BeautifulSoup
-from django.conf import settings
 from django.shortcuts import redirect
 from django.urls import re_path
 
@@ -12,16 +9,39 @@ from ..source import ProxySource
 from ..source.data import ChapterAPI, SeriesAPI, SeriesPage
 from ..source.helpers import api_cache, get_wrapper
 
-
 class Dynasty(ProxySource):
     def get_reader_prefix(self):
         return "dynasty"
-
+    
     def shortcut_instantiator(self):
         def handler(request, raw_url):
             if "/chapters/" in raw_url:
-                slug_name = self.get_slug_name(self.normalize_slug(raw_url))
-                canonical_chapter = self.parse_chapter(raw_url)
+                try:
+                    canonical_chapter = self.parse_chapter(raw_url)
+                    slug_name = self.get_slug_name(self.normalize_slug(raw_url))
+                except ValueError:
+                    # attempt to fetch the series name, otherwise fall back to the full slug
+                    chapter_url = raw_url + ".json"
+                    resp = get_wrapper(chapter_url)
+                    if resp.status_code == 200:
+                        data = resp.json()
+                        series_slug = next(
+                            (tag["permalink"] for tag in data["tags"] if tag["type"] == "Series"),
+                            None
+                        )
+                        if series_slug is None:
+                            # eg. https://dynasty-scans.com/chapters/wanna_sip
+                            slug_name = self.get_slug_name(raw_url)
+                            canonical_chapter = "1"
+                        else:
+                            # eg. https://dynasty-scans.com/chapters/bloom_into_you_volume_1_extras
+                            slug_name = series_slug
+                            canonical_chapter = self.get_slug_name(raw_url).replace(
+                                series_slug + "_", ""
+                            )
+                    else:
+                        return None
+                
                 print(slug_name, canonical_chapter)
                 return redirect(
                     f"reader-{self.get_reader_prefix()}-chapter-page",
@@ -34,9 +54,9 @@ class Dynasty(ProxySource):
                     f"reader-{self.get_reader_prefix()}-series-page",
                     self.get_slug_name(self.normalize_slug(raw_url)),
                 )
-
+        
         return [re_path(r"^ds/(?P<raw_url>[\w\d\/:.-]+)", handler)]
-
+    
     @staticmethod
     def normalize_slug(denormal):
         if "/chapters/" in denormal:
@@ -48,89 +68,115 @@ class Dynasty(ProxySource):
             denormal = "https:/" + "/".join(denormal)
             denormal = denormal.replace("/chapters/", "/series/")
         return denormal
-
+    
     @staticmethod
     def get_slug_name(normalized_url):
         return normalized_url.split("/")[-1]
-
+    
     @staticmethod
     def parse_chapter(raw_url):
-        int(raw_url.split("ch")[-1])
-        return raw_url.split("ch")[-1].replace("_", ".")
-
-    def ds_scrape_common(self, meta_id):
+        int(raw_url.rsplit("ch")[-1])
+        return raw_url.rsplit("ch")[-1].replace("_", ".")
+    
+    @staticmethod
+    def parse_date(date):
+        date_format = "%Y-%m-%d"
+        output_date_format = "%d-%m-%Y"
+        return datetime.strptime(
+            date,
+            date_format,
+        ).strftime(output_date_format)
+    
+    def ds_api_common(self, meta_id):
         base_url = "https://dynasty-scans.com"
-        series_url = "https://dynasty-scans.com/series/" + meta_id
+        series_url = f"https://dynasty-scans.com/series/{meta_id}.json"
         resp = get_wrapper(series_url)
         if resp.status_code == 200:
-            data = resp.text
-            soup = BeautifulSoup(data, "html.parser")
-            try:
-                title = soup.find("h2").find("b").contents[0]
-            except AttributeError:
-                return None
+            data = resp.json()
+            
+            original_url = f"https://dynasty-scans.com/series/{meta_id}"
+            title = data["name"]
+            alt_titles = data["aliases"]
+            
+            if data["description"] is not None:
+                soup = BeautifulSoup(data["description"], "html.parser")
+                description = soup.get_text("\n").strip()
+            else:
+                description = "No description."
 
-            author = "None"
-            description = soup.find("div", class_="description").find("p").contents[0]
-            try:
-                author = soup.find("h2").find("a").contents[0]
-            except:
-                pass
-            try:
-                cover = (
-                    base_url + soup.find("div", class_="span2 cover").find("img")["src"]
-                )
-            except:
+            author = next(
+                (tag["name"] for tag in data["tags"] if tag["type"] == "Author"), "Unknown"
+            )
+            
+            if data["cover"] is not None:
+                cover = base_url + data["cover"]
+            else:
                 cover = ""
-            groups_dict = {"1": "Dynasty Scans"}
-
+            
+            # fetch scanlation groups
+            groups_dict = {}
+            groups_map = {}
+            group_index = 0
+            for tagging in data["taggings"]:
+                if "tags" in tagging:
+                    groups = [tag["name"] for tag in tagging["tags"] if tag["type"] == "Scanlator"]
+                    group = ", ".join(groups)
+                    if group not in groups_map:
+                        groups_dict[str(group_index)] = group
+                        groups_map[group] = str(group_index)
+                        group_index += 1
+            
             chapter_list = []
             chapter_dict = {}
-            chapter_data = soup.find("dl", class_="chapter-list").find_all("dd")
-            chapters = []
-            date_format = "%b %d '%y"
-            output_date_format = "%d-%m-%Y"
-            for ch in chapter_data:
-                chapters.append(
-                    [
-                        ch.find("a", class_="name").contents[0],
-                        base_url + ch.find("a", class_="name")["href"],
-                        datetime.strptime(
-                            ch.find("small").contents[0].replace("released ", ""),
-                            date_format,
-                        ).strftime(output_date_format),
+            volume = None
+            
+            for tagging in data["taggings"]:            
+                if "header" in tagging:
+                    match =  re.match(r"Volume (\d+)", tagging["header"])
+                    if match is None:
+                        volume = None
+                    else:
+                        volume = match.group(1)
+                else:
+                    try:
+                        canonical_chapter = self.parse_chapter(tagging["permalink"])
+                    except ValueError:
+                        canonical_chapter = tagging["permalink"].replace(meta_id + "_", "")
+                    chapter_title = tagging["title"]
+                    upload_date = self.parse_date(tagging["released_on"])
+                    groups = [
+                        tag["name"] for tag in tagging["tags"] if tag["type"] == "Scanlator"
                     ]
-                )
-            for chapter in chapters:
-                try:
-                    canonical_chapter = self.parse_chapter(chapter[1])
+                    group = ", ".join(groups)
+                    
                     chapter_list.append(
                         [
-                            "",
-                            canonical_chapter,
-                            chapter[0],
-                            canonical_chapter.replace(".", "-"),
-                            "Dynasty Scans",
-                            chapter[2],
-                            "",
+                        "",
+                        canonical_chapter,
+                        chapter_title,
+                        canonical_chapter.replace(".", "-"),
+                        group,
+                        upload_date,
+                        volume,
                         ]
                     )
+                    
                     chapter_dict[canonical_chapter] = {
-                        "volume": "1",
-                        "title": chapter[0],
-                        "groups": {
-                            "1": self.wrap_chapter_meta(self.get_slug_name(chapter[1]))
+                        "volume": volume,
+                        "title": chapter_title,
+                        "groups":
+                        {
+                        groups_map[group]:
+                        self.wrap_chapter_meta(self.get_slug_name(tagging["permalink"]))
                         },
                     }
-                except:
-                    pass
+            
             return {
                 "slug": meta_id,
                 "title": title,
                 "description": description,
                 "series": title,
-                "alt_titles_str": None,
-                "cover_vol_url": cover,
+                "alt_titles": alt_titles,
                 "metadata": [],
                 "author": author,
                 "artist": author,
@@ -138,13 +184,71 @@ class Dynasty(ProxySource):
                 "cover": cover,
                 "chapter_dict": chapter_dict,
                 "chapter_list": chapter_list,
+                "original_url": original_url
             }
         else:
-            return None
-
+            # Oneshots
+            chapter_url = f"https://dynasty-scans.com/chapters/{meta_id}.json"
+            resp = get_wrapper(chapter_url)
+            
+            if resp.status_code == 200:
+                data = resp.json()
+                
+                original_url = f"https://dynasty-scans.com/chapters/{meta_id}"
+                title = data["title"]
+                description = "No description."
+                author = next(
+                    (tag["name"] for tag in data["tags"] if tag["type"] == "Author"), "Unknown"
+                )
+                cover = base_url + data["pages"][0]["url"]
+                upload_date = self.parse_date(data["released_on"])
+                
+                groups = [tag["name"] for tag in data["tags"] if tag["type"] == "Scanlator"]
+                group = ", ".join(groups)
+                groups_dict = {"1": group}
+                
+                chapter_list = [[
+                    "",
+                    "1",
+                    title,
+                    "1",
+                    group,
+                    upload_date,
+                    "1",
+                ]]
+                
+                chapter_dict = {
+                    "1":
+                    {
+                    "volume": "1",
+                    "title": title,
+                    "groups": {
+                    "1": self.wrap_chapter_meta(self.get_slug_name(data["permalink"]))
+                    },
+                    }
+                }
+                
+                return {
+                    "slug": meta_id,
+                    "title": title,
+                    "description": description,
+                    "series": title,
+                    "alt_titles": None,
+                    "metadata": [],
+                    "author": author,
+                    "artist": author,
+                    "groups": groups_dict,
+                    "cover": cover,
+                    "chapter_dict": chapter_dict,
+                    "chapter_list": chapter_list,
+                    "original_url": original_url
+                }
+            else:
+                return None
+    
     @api_cache(prefix="ds_series_dt", time=600)
     def series_api_handler(self, meta_id):
-        data = self.ds_scrape_common(meta_id)
+        data = self.ds_api_common(meta_id)
         if data:
             return SeriesAPI(
                 slug=data["slug"],
@@ -158,40 +262,33 @@ class Dynasty(ProxySource):
             )
         else:
             return None
-
+    
     @api_cache(prefix="ds_chapter_dt", time=3600)
     def chapter_api_handler(self, meta_id):
         base_url = "https://dynasty-scans.com"
-        chapter_url = "https://dynasty-scans.com/chapters/" + meta_id
+        chapter_url = f"https://dynasty-scans.com/chapters/{meta_id}.json"
         resp = get_wrapper(chapter_url)
         if resp.status_code == 200:
-            data = resp.text
-            try:
-                m = re.search(r"pages\s?=\s?.+\;", data)
-                arr = str(m.group(0)).split()[2].strip(";")
-                arr = ast.literal_eval(arr)
-                pages = [(base_url + seg["image"]) for seg in arr]
-                return ChapterAPI(pages=pages, series=meta_id, chapter="")
-            except:
-                return None
-
+            data = resp.json()
+            pages = [base_url + page["url"] for page in data["pages"]]
+            return ChapterAPI(pages=pages, series=meta_id, chapter=data["title"])
+    
     @api_cache(prefix="ds_series_page_dt", time=600)
     def series_page_handler(self, meta_id):
-        data = self.ds_scrape_common(meta_id)
-        original_url = "https://dynasty-scans.com/series/" + meta_id
-
+        data = self.ds_api_common(meta_id)
+        
         if data:
             return SeriesPage(
                 series=data["title"],
-                alt_titles=[],
+                alt_titles=data["alt_titles"],
                 alt_titles_str=None,
                 slug=data["slug"],
                 cover_vol_url=data["cover"],
                 metadata=[],
                 synopsis=data["description"],
-                author=data["artist"],
+                author=data["author"],
                 chapter_list=data["chapter_list"],
-                original_url=original_url,
+                original_url=data["original_url"],
             )
         else:
             return None

--- a/proxy/templates/reader/series.html
+++ b/proxy/templates/reader/series.html
@@ -1,9 +1,9 @@
 {% extends "layout.html" %} {% load static %}
 {% block meta %}
 <title>Read {{ series }} | {{ brand.name }}</title>
-<meta name="twitter:description" content="Read {{ series }}{% if author %} by {{ author }} {% endif %} on Cubari, the manga image proxy." />
-<meta property="og:description" content="Read {{ series }}{% if author %} by {{ author }} {% endif %} on Cubari, the manga image proxy." />
-<meta name="description" content="Read {{ series }}{% if author %} by {{ author }} {% endif %} on Cubari, the manga image proxy." />
+<meta name="twitter:description" content="Read {{ series }}{% if author %} by {{ author }}{% endif %} on Cubari, the manga image proxy." />
+<meta property="og:description" content="Read {{ series }}{% if author %} by {{ author }}{% endif %} on Cubari, the manga image proxy." />
+<meta name="description" content="Read {{ series }}{% if author %} by {{ author }}{% endif %} on Cubari, the manga image proxy." />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:title" content="Read {{ series }} | {{ brand.name }}" />
 <meta name="twitter:image" content="{{ brand.image_url }}" />

--- a/static_global/js/main.js
+++ b/static_global/js/main.js
@@ -63,6 +63,11 @@ let error = '';
 			if(!result || !result[1]) return message('Reader could not understand the given link.', 1);
 			result = '/read/catbox/' + result[1];
 			break;
+		case /dynasty-scans\.com/.test(text):
+			result = /dynasty-scans\.com\/series\/(\w+)/i.exec(text);
+			if (!result || !result[1]) return message('Reader could not understand the given link.', 1);
+			result = '/read/dynasty/' + result[1];
+			break;
 		default:
 			return message('Reader could not understand the given link.', 1)
 			break;


### PR DESCRIPTION
I rewrote the Dynasty-Scans source functionality to add some additional features/bugfixes:

- Use the undocumented ["official"](https://dynasty-scans.com/forum/topics/7186-dynasty-reader-api?page=1#forum_post_151548) JSON API instead of scraping HTML
- oneshot chapter support
- support for "extra" chapters
- alternate titles
- correct scanlation group fields
- correct volume field
- **doesn't fail if the series description is missing**

Test cases:
- https://dynasty-scans.com/chapters/wanna_sip (oneshot)
- https://dynasty-scans.com/chapters/bloom_into_you_volume_1_extras (non-standard chapter slug)
- https://dynasty-scans.com/series/i_favor_the_villainess (multi-paragraph description, alt titles)
- https://dynasty-scans.com/series/bloom_into_you_comic_anthology (no cover image, no description)
- https://dynasty-scans.com/series/please_bully_me_miss_villainess (non-standard "volume" title)
- https://dynasty-scans.com/chapters/its_probably_love (oneshot, multiple SL groups)