### PR TITLE
feat(nhentai): proxy source for the new v2 official REST API

### DIFF
--- a/proxy/__init__.py
+++ b/proxy/__init__.py
@@ -5,7 +5,7 @@ from .sources.imgbb import Imgbb
 from .sources.imgur import Imgur
 # from .sources.mangabox import MangaBox
 from .sources.mangadex import MangaDex
-from .sources.nhentai import NHentai
+from .sources.nhentai_rest import NHentai
 from .sources.readmanhwa import ReadManhwa
 # from .sources.hitomi import Hitomi
 from .sources.gist import Gist

--- a/proxy/sources/nhentai_rest.py
+++ b/proxy/sources/nhentai_rest.py
@@ -1,0 +1,185 @@
+import json
+from datetime import datetime
+
+from django.shortcuts import redirect
+from django.urls import re_path
+from django.conf import settings
+
+from ..source import ProxySource
+from ..source.data import ChapterAPI, SeriesAPI, SeriesPage
+from ..source.helpers import api_cache, encode, get_wrapper
+
+import logging as log
+
+log.basicConfig(
+    level=log.INFO,
+    format="%(levelname)s: %(message)s"
+)
+
+class NHentai(ProxySource):
+    def cache_duration(self) -> int:
+        return 60 * 60 * 60 * 6
+
+    def get_reader_prefix(self):
+        return "nhentai"
+
+    def shortcut_instantiator(self):
+        def handler(request, series_id, page=None):
+            if page:
+                return redirect(
+                    f"reader-{self.get_reader_prefix()}-chapter-page",
+                    series_id,
+                    "1",
+                    page,
+                )
+            else:
+                return redirect(
+                    f"reader-{self.get_reader_prefix()}-chapter-page",
+                    series_id,
+                    "1",
+                    "1",
+                )
+
+        def series(request, series_id):
+            return redirect(f"reader-{self.get_reader_prefix()}-series-page", series_id)
+
+        def series_chapter(request, series_id, chapter, page="1"):
+            return redirect(
+                f"reader-{self.get_reader_prefix()}-chapter-page",
+                series_id,
+                chapter,
+                page,
+            )
+
+        return [
+            re_path(r"^g/(?P<series_id>[\d]{1,9})/$", handler),
+            re_path(r"^g/(?P<series_id>[\d]{1,9})/(?P<page>[\d]{1,9})/$", handler),
+        ]
+
+    @api_cache(prefix="nh_series_common_dt", time=3600)
+    def nh_api_common(self, meta_id):
+        nh_series_api = f"https://nhentai.net/api/v2/galleries/{meta_id}"
+        resp = get_wrapper(nh_series_api, use_proxy=False, secondary=True)
+
+        if resp.status_code != 200:
+            resp = get_wrapper(
+                f"{settings.EXTERNAL_PROXY_URL}/v2/cors/{encode(nh_series_api)}?source=cubari_host"
+            )
+
+        log.info(f"Got {resp=} for {nh_series_api}")
+
+        if resp.status_code == 200:
+            data = resp.text
+            api_data = json.loads(data)
+
+            artist = api_data["scanlator"]
+            group = api_data["scanlator"]
+            lang_list = []
+            tag_list = []
+            for tag in api_data["tags"]:
+                if tag["type"] == "artist":
+                    artist = tag["name"]
+                elif tag["type"] == "group":
+                    group = tag["name"]
+                elif tag["type"] == "language":
+                    lang_list.append(tag["name"])
+                elif tag["type"] == "tag":
+                    tag_list.append(tag["name"])
+            pages_list = []
+            for p, t in enumerate(api_data["pages"]):
+                pages_list.append(
+                    f"https://i3.nhentai.net/{t['path']}"
+                )
+            groups_dict = {"1": group or "N-Hentai"}
+            chapters_dict = {
+                "1": {
+                    "volume": "1",
+                    "title": api_data["title"]["pretty"]
+                    or api_data["title"]["english"],
+                    "groups": {"1": pages_list},
+                }
+            }
+            final = {
+                "slug": meta_id,
+                "title": api_data["title"]["pretty"] or api_data["title"]["english"],
+                "description": api_data["title"]["english"],
+                "group": group,
+                "artist": artist,
+                "groups": groups_dict,
+                "tags": tag_list,
+                "lang": ", ".join(lang_list),
+                "chapters": chapters_dict,
+                "cover": f"https://t2.nhentai.net/{api_data['cover']['path']}",
+                "timestamp": api_data["upload_date"],
+            }
+
+            return final
+        else:
+            return None
+
+    @api_cache(prefix="nh_series_dt", time=3600)
+    def series_api_handler(self, meta_id):
+        data = self.nh_api_common(meta_id)
+        if data:
+            return SeriesAPI(
+                slug=meta_id,
+                title=data["title"],
+                description=data["description"],
+                author=data["artist"],
+                artist=data["artist"],
+                groups=data["groups"],
+                cover=data["cover"],
+                chapters=data["chapters"],
+            )
+        else:
+            return None
+
+    @api_cache(prefix="nh_pages_dt", time=3600)
+    def chapter_api_handler(self, meta_id):
+        data = self.nh_api_common(meta_id)
+        if data:
+            return ChapterAPI(
+                pages=data["chapters"]["1"]["groups"]["1"],
+                series=data["slug"],
+                chapter="1",
+            )
+        else:
+            return None
+
+    @api_cache(prefix="nh_series_page_dt", time=3600)
+    def series_page_handler(self, meta_id):
+        data = self.nh_api_common(meta_id)
+        if data:
+            date = datetime.utcfromtimestamp(data["timestamp"])
+            chapter_list = [
+                [
+                    "1",
+                    "1",
+                    data["title"],
+                    "1",
+                    data["group"] or "NHentai",
+                    [
+                        date.year,
+                        date.month - 1,
+                        date.day,
+                        date.hour,
+                        date.minute,
+                        date.second,
+                    ],
+                    "1",
+                ]
+            ]
+            return SeriesPage(
+                series=data["title"],
+                alt_titles=[],
+                alt_titles_str=None,
+                slug=data["slug"],
+                cover_vol_url=data["cover"],
+                metadata=[["Author", data["artist"]], ["Artist", data["artist"]]],
+                synopsis=f"{data['description']}\n\nTags: {', '.join(data['tags'])}",
+                author=data["artist"],
+                chapter_list=chapter_list,
+                original_url=f"https://nhentai.net/g/{meta_id}/",
+            )
+        else:
+            return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ django-extensions==2.1.9
 django-ratelimit==2.0.0
 Markdown==3.1.1
 Pillow==8.1.1
-psycopg2==2.8.4
+psycopg2-binary==2.8.4
 python-memcached==1.59
 requests==2.22.0
 beautifulsoup4==4.8.2


### PR DESCRIPTION
API docs: https://nhentai.net/api/v2/docs

nHentai recently made the scraping method unreliable and subsequently launched the official REST API. This pull request introduces a new proxy source utilizing this REST API.

3.6 has long reached EOL, as a result I've had difficulties getting a development environment working as the package frontend I use, `uv`, couldn't pin to a 3.6 release. However, `3.7` appeared to work. When I tried to build the package in that version, I had difficulties compiling the package `psycopg2`, and the error suggested to try using `psycopg2-binary`. I faced no further difficulties in getting the project up and running with the new `psycopg2-binary` dependency, locked to same version as the original `psycopg2`. I decided to include that `requirements.txt` change assuming that there's also a prebuilt binary for Cubari's production server's archicture, which it should if it's AMD64.

But I can get rid of that dependency change before you merge this if needed. Just let me know.